### PR TITLE
Develop_gc branch with prometheus metrics generation for light-rest-4j

### DIFF
--- a/light-rest-4j/src/main/resources/templates/rest/openapi/handlerProvider.rocker.raw
+++ b/light-rest-4j/src/main/resources/templates/rest/openapi/handlerProvider.rocker.raw
@@ -1,6 +1,6 @@
 @import java.util.Map
 @import java.util.List
-@args (String rootPackage, String handlerPackage, List<Map<String, Object>> items)
+@args (String rootPackage, String handlerPackage, List<Map<String, Object>> items, boolean prometheusMetrics)
 package @rootPackage;
 
 import com.networknt.config.Config;
@@ -11,6 +11,9 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Methods;
 import com.networknt.info.ServerInfoGetHandler;
 import com.networknt.health.HealthGetHandler;
+@if(prometheusMetrics){
+import com.networknt.metrics.prometheus.PrometheusGetHandler;
+}
 import @with (p = handlerPackage + ".*;") {@p}
 
 public class PathHandlerProvider implements HandlerProvider {

--- a/light-rest-4j/src/main/resources/templates/rest/openapi/pom.xml.rocker.raw
+++ b/light-rest-4j/src/main/resources/templates/rest/openapi/pom.xml.rocker.raw
@@ -109,6 +109,13 @@
             <artifactId>metrics</artifactId>
             <version>${version.light-4j}</version>
         </dependency>
+        @if(config.toBoolean("prometheusMetrics")){
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>prometheus</artifactId>
+            <version>${version.light-4j}</version>
+        </dependency>
+        }
         <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>handler</artifactId>

--- a/light-rest-4j/src/main/resources/templates/rest/openapi/service.yml.rocker.raw
+++ b/light-rest-4j/src/main/resources/templates/rest/openapi/service.yml.rocker.raw
@@ -66,7 +66,11 @@ singletons:
   # Exception Global exception handler that needs to be called first to wrap all middleware handlers and business handlers
   - com.networknt.exception.ExceptionHandler
   # Metrics handler to calculate response time accurately, this needs to be the second handler in the chain.
+  @if(config.toBoolean("prometheusMetrics")){
+  - com.networknt.metrics.prometheus.PrometheusHandler
+  } else {
   - com.networknt.metrics.MetricsHandler
+  }
   # Traceability Put traceabilityId into response header from request header if it exists
   - com.networknt.traceability.TraceabilityHandler
   # Correlation Create correlationId if it doesn't exist in the request header and put it into the request header

--- a/light-rest-4j/src/main/resources/templates/rest/openapi/service.yml.rocker.raw
+++ b/light-rest-4j/src/main/resources/templates/rest/openapi/service.yml.rocker.raw
@@ -66,11 +66,7 @@ singletons:
   # Exception Global exception handler that needs to be called first to wrap all middleware handlers and business handlers
   - com.networknt.exception.ExceptionHandler
   # Metrics handler to calculate response time accurately, this needs to be the second handler in the chain.
-  @if(config.toBoolean("prometheusMetrics")){
-  - com.networknt.metrics.prometheus.PrometheusHandler
-  } else {
-  - com.networknt.metrics.MetricsHandler
-  }
+  @if(config.toBoolean("prometheusMetrics")){- com.networknt.metrics.prometheus.PrometheusHandler} else {- com.networknt.metrics.MetricsHandler}
   # Traceability Put traceabilityId into response header from request header if it exists
   - com.networknt.traceability.TraceabilityHandler
   # Correlation Create correlationId if it doesn't exist in the request header and put it into the request header

--- a/light-rest-4j/src/main/resources/templates/rest/swagger/handlerProvider.rocker.raw
+++ b/light-rest-4j/src/main/resources/templates/rest/swagger/handlerProvider.rocker.raw
@@ -1,7 +1,7 @@
 @import java.util.Map
 @import java.util.List
 @import com.jsoniter.any.Any
-@args (String rootPackage, String handlerPackage, List<Map<String, Any>> items)
+@args (String rootPackage, String handlerPackage, List<Map<String, Any>> items, boolean prometheusMetrics)
 package @rootPackage;
 
 import com.networknt.config.Config;
@@ -12,6 +12,9 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Methods;
 import com.networknt.info.ServerInfoGetHandler;
 import com.networknt.health.HealthGetHandler;
+@if(prometheusMetrics){
+import com.networknt.metrics.prometheus.PrometheusGetHandler;
+}
 import @with (p = handlerPackage + ".*;") {@p}
 
 public class PathHandlerProvider implements HandlerProvider {

--- a/light-rest-4j/src/main/resources/templates/rest/swagger/pom.xml.rocker.raw
+++ b/light-rest-4j/src/main/resources/templates/rest/swagger/pom.xml.rocker.raw
@@ -109,6 +109,13 @@
             <artifactId>metrics</artifactId>
             <version>${version.light-4j}</version>
         </dependency>
+        @if(config.toBoolean("prometheusMetrics")){
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>prometheus</artifactId>
+            <version>${version.light-4j}</version>
+        </dependency>
+        }
         <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>handler</artifactId>

--- a/light-rest-4j/src/main/resources/templates/rest/swagger/service.yml.rocker.raw
+++ b/light-rest-4j/src/main/resources/templates/rest/swagger/service.yml.rocker.raw
@@ -17,7 +17,11 @@ singletons:
   # Exception Global exception handler that needs to be called first to wrap all middleware handlers and business handlers
   - com.networknt.exception.ExceptionHandler
   # Metrics handler to calculate response time accurately, this needs to be the second handler in the chain.
+  @if(config.toBoolean("prometheusMetrics")){
+  - com.networknt.metrics.prometheus.PrometheusHandler
+  } else {
   - com.networknt.metrics.MetricsHandler
+  }
   # Traceability Put traceabilityId into response header from request header if it exists
   - com.networknt.traceability.TraceabilityHandler
   # Correlation Create correlationId if it doesn't exist in the request header and put it into the request header

--- a/light-rest-4j/src/main/resources/templates/rest/swagger/service.yml.rocker.raw
+++ b/light-rest-4j/src/main/resources/templates/rest/swagger/service.yml.rocker.raw
@@ -17,11 +17,7 @@ singletons:
   # Exception Global exception handler that needs to be called first to wrap all middleware handlers and business handlers
   - com.networknt.exception.ExceptionHandler
   # Metrics handler to calculate response time accurately, this needs to be the second handler in the chain.
-  @if(config.toBoolean("prometheusMetrics")){
-  - com.networknt.metrics.prometheus.PrometheusHandler
-  } else {
-  - com.networknt.metrics.MetricsHandler
-  }
+  @if(config.toBoolean("prometheusMetrics")){- com.networknt.metrics.prometheus.PrometheusHandler} else {- com.networknt.metrics.MetricsHandler}
   # Traceability Put traceabilityId into response header from request header if it exists
   - com.networknt.traceability.TraceabilityHandler
   # Correlation Create correlationId if it doesn't exist in the request header and put it into the request header


### PR DESCRIPTION
Add option for generate project which use Prometheus metrics handler as metrics MiddlewareHandler handler

If user want to use Prometheus metrics handler as metrics MiddlewareHandler handler for the service, simply set the config "prometheusMetrics" as true

Here is an example of config.json for openapi generator.

```
{
  "name": "petstore",
  "version": "1.0.1",
  "groupId": "com.networknt",
  "artifactId": "petstore",
  "rootPackage": "com.networknt.petstore",
  "handlerPackage":"com.networknt.petstore.handler",
  "modelPackage":"com.networknt.petstore.model",
  "overwriteHandler": true,
  "overwriteHandlerTest": true,
  "overwriteModel": true,
  "httpPort": 8080,
  "enableHttp": true,
  "httpsPort": 8443,
  "enableHttps": false,
  "enableRegistry": false,
  "supportDb": true,
  "dbInfo": {
    "name": "mysql",
    "driverClassName": "com.mysql.jdbc.Driver",
    "jdbcUrl": "jdbc:mysql://mysqldb:3306/oauth2?useSSL=false",
    "username": "root",
    "password": "my-secret-pw"
  },
  "supportH2ForTest": false,
  "supportClient": false,
  "prometheusMetrics": true
}
```
