### PR TITLE
fixes #394

### DIFF
--- a/light-rest-4j/src/test/resources/openapi-enum.yaml
+++ b/light-rest-4j/src/test/resources/openapi-enum.yaml
@@ -133,8 +133,8 @@ components:
           description: Category name
           type: string
           enum:
-            - CPP : Canada pension plan
-            - OAS : Ontario Age Service
+            - CPP:Canada pension plan
+            - OAS:Ontario Age Service
         aggregatedAmount:
           type: number
           format: int64


### PR DESCRIPTION
change sample API spec:
            - CPP:Canada pension plan
            - OAS:Ontario Age Service

It shouldn't have space. Otherwise it treat as swagger fields