### PR TITLE
fix #409 snapshot version in Kotlin REST template gradle.properties

### DIFF
--- a/light-rest-4j/src/main/resources/templates/restkotlin/gradleProperties.rocker.raw
+++ b/light-rest-4j/src/main/resources/templates/restkotlin/gradleProperties.rocker.raw
@@ -2,7 +2,7 @@
 @args (Any config)
 # Versions of Frequently used Libraries
 kafkaVersion=2.0.0
-light4jVersion=1.6.13
+light4jVersion=1.6.14-SNAPSHOT
 jacksonVersion=2.10.0
 jacksonDatabindVersion=2.10.0
 undertowVersion=2.0.28.Final


### PR DESCRIPTION
This builds on PR #411 to use the 1.6.14-SNAPSHOT version instead of the previous release version, to ensure that the next version upgrade works correctly.