### PR TITLE
fix #409 Update light4j to snapshot version in Kotlin REST template

### DIFF
--- a/light-rest-4j/src/main/resources/templates/restkotlin/gradleProperties.rocker.raw
+++ b/light-rest-4j/src/main/resources/templates/restkotlin/gradleProperties.rocker.raw
@@ -2,7 +2,7 @@
 @args (Any config)
 # Versions of Frequently used Libraries
 kafkaVersion=2.0.0
-light4jVersion=2.0.9
+light4jVersion=2.0.10-SNAPSHOT
 jacksonVersion=2.10.0
 undertowVersion=2.0.28.Final
 logbackVersion=1.2.3


### PR DESCRIPTION
Use the 2.0.10-SNAPSHOT version instead of last release to ensure that next version upgrade works properly.