### PR TITLE
Fix NullPointerException in template file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [2.1.33](https://github.com/networknt/light-codegen/tree/2.1.33) (2024-03-31)
+
+
+**Merged pull requests:**
+
+
+- fixes \#678 change logger-config to logger-handler in pom.xml [\#679](https://github.com/networknt/light-codegen/pull/679) ([stevehu](https://github.com/stevehu))
+
+
 ## [2.1.32](https://github.com/networknt/light-codegen/tree/2.1.32) (2024-02-27)
 
 

--- a/light-hybrid-4j/src/main/java/com/networknt/codegen/hybrid/HybridServerGenerator.java
+++ b/light-hybrid-4j/src/main/java/com/networknt/codegen/hybrid/HybridServerGenerator.java
@@ -57,6 +57,7 @@ public class HybridServerGenerator implements HybridGenerator {
         String decryptOption = getDecryptOption(config, null);
         String jsonPath = getJsonPath(config, null);
         boolean buildMaven = isBuildMaven(config, null);
+        boolean supportDb = isSupportDb(config, null);
         if(buildMaven) {
             transfer(targetPath, "", "pom.xml", templates.hybrid.server.pom.template(config));
             transferMaven(targetPath);


### PR DESCRIPTION
version: 2.1.33

`java -jar light-codegen/codegen-cli/target/codegen-cli.jar -f light-hybrid-4j-server -o light-example-4j/hybrid/generic-server -c model-config/hybrid/generic-server/config.json`

Because i want to build with Maven, So i add a line in model-config/hybrid/generic-server/config.json.
`"buildMaven": true`

The screenshot of the error is as follows:
![image](https://github.com/networknt/light-codegen/assets/58244032/e59ae4e5-f538-4ca0-ac60-c8155a012280)

Then I checked this file: templates/hybrid/server/pom.xml.rocker.raw
![image](https://github.com/networknt/light-codegen/assets/58244032/d3861d08-ab77-4aa7-9f79-2fefe6c3aff1)

At first, I thought the problem was with this piece of code.
`config.get("supportDb").booleanValue()`

However, `supportAvro` did not have this issue.

Finally, I found that Generator.isSupportDb is not invoked in HybridServerGenerator.generate, which will result in the supportDb attribute in JsonNode being null.
![image](https://github.com/networknt/light-codegen/assets/58244032/cd13f20e-e040-40fe-977a-b48988e94dd9)


