### PR TITLE
Remove extraneous semicolon in lambda and lambdanative template

### DIFF
--- a/light-rest-4j/src/main/resources/templates/lambda/template.yaml.rocker.raw
+++ b/light-rest-4j/src/main/resources/templates/lambda/template.yaml.rocker.raw
@@ -1,7 +1,7 @@
 @import java.util.Map
 @import java.util.List
-@import com.networknt.codegen.rest.AbstractLambdaGenerator.OpenApiPath;
-@import com.networknt.codegen.rest.AbstractLambdaGenerator.MethodFunction;
+@import com.networknt.codegen.rest.AbstractLambdaGenerator.OpenApiPath
+@import com.networknt.codegen.rest.AbstractLambdaGenerator.MethodFunction
 @args (String projectName, String handlerPackage, boolean packageDocker, boolean useLightProxy, List<Map<String, Object>> operationList, List<OpenApiPath> pathList)
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31

--- a/light-rest-4j/src/main/resources/templates/lambdanative/template.yaml.rocker.raw
+++ b/light-rest-4j/src/main/resources/templates/lambdanative/template.yaml.rocker.raw
@@ -1,7 +1,7 @@
 @import java.util.Map
 @import java.util.List
-@import com.networknt.codegen.rest.AbstractLambdaGenerator.OpenApiPath;
-@import com.networknt.codegen.rest.AbstractLambdaGenerator.MethodFunction;
+@import com.networknt.codegen.rest.AbstractLambdaGenerator.OpenApiPath
+@import com.networknt.codegen.rest.AbstractLambdaGenerator.MethodFunction
 @args (String artifactId, String serviceId, String handlerPackage, boolean packageDocker, String lambdaTrigger, List<Map<String, Object>> operationList, List<OpenApiPath> pathList)
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31


### PR DESCRIPTION
Description
This pull request addresses an issue in the template.yaml.rocker.raw file where there was an extraneous semicolon (;;) in the import statement:
`import com.networknt.codegen.rest.AbstractLambdaGenerator.OpenApiPath;;
`

Changes made:
Removed the extra semicolon in the import statement to fix the compilation error.